### PR TITLE
Basic Nomad Integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,36 @@
-FROM rust:1 as builder
+# FROM rust:1 as builder
+# 
+# WORKDIR /app
+# 
+# COPY . /app
+# 
+# RUN cargo build --release
 
-WORKDIR /app
+# For the bot executor
+FROM centos:stream9
 
-COPY . /app
-RUN cargo build --release
+# We are doing podman-alongside-podman with podman remote
+# Just use podman remote instead of trying to nest containers
+RUN dnf install -y podman-remote
 
+# Clean out dnf caches to save space
+RUN rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-# To run locally with podman:
-# podman run --security-opt label=disable --device /dev/fuse --cap-add=CAP_NET_ADMIN --env-file .env ferrisbot:latestp
-FROM quay.io/containers/podman:latest
+RUN useradd ferris; \
+echo ferris:10000:5000 > /etc/subuid; \
+echo ferris:10000:5000 > /etc/subgid;
+
 
 # Need this environment variable to tell ferris-bot it's inside a container
-# Not all features are supported within the container
+# This tells the bot to use podman-remote instead of podman
 ENV IS_RUNNING_IN_CONTAINER="true"
+ENV CONTAINER_HOST="unix:/run/podman/podman.sock"
 
-COPY --from=builder /app/target/release/ferris-bot /app/ferris-bot
+# For local development
+COPY ./target/release/ferris-bot /app/ferris-bot
+# For using the builder image
+# COPY --from=builder /app/target/release/ferris-bot /app/ferris-bot
 
-USER podman
+USER ferris;
 
 ENTRYPOINT ["/app/ferris-bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY . /app
 RUN cargo build --release
 
 
+# To run locally with podman:
+# podman run --security-opt label=disable --device /dev/fuse --cap-add=CAP_NET_ADMIN --env-file .env ferrisbot:latestp
 FROM quay.io/containers/podman:latest
 
 # Need this environment variable to tell ferris-bot it's inside a container
@@ -13,5 +15,7 @@ FROM quay.io/containers/podman:latest
 ENV IS_RUNNING_IN_CONTAINER="true"
 
 COPY --from=builder /app/target/release/ferris-bot /app/ferris-bot
+
+USER podman
 
 ENTRYPOINT ["/app/ferris-bot"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Ferris-Bot
+
+## Development
+
+You will need a discord bot token with the appropriate scopes and permissions to use slash commands. Create a `.env` file with the following content:
+```
+DISCORD_TOKEN=YOUR_TOKEN_HERE
+```
+
+Ferris-Bot supports running in 2 different modes
+- **Run directly on host**: the bot will run directly on your host as a regular process. Your host needs [podman](https://podman.io/) installed as the bot invokes podman to run containers for executing code. To run Ferris-Bot this way, simply use `cargo run`
+- **Run as a container**: the bot will run as a container and spawn nested containers for executing code. Running this way is a little more work:
+
+  First, to build the image locally (this will compile the bot in release mode, may take a long time):
+  ```bash
+  podman build -t ferrisbot:latest .
+  ```
+
+  After the container is built, it can be ran using rootless podman
+  ```
+  podman run --rm --security-opt label=disable --device /dev/fuse --env-file .env ferrisbot:latest
+  ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,27 @@ Ferris-Bot supports running in 2 different modes
   podman build -t ferrisbot:latest .
   ```
 
-  After the container is built, it can be ran using rootless podman
+  After the container is built, it can be ran using rootless Podman. To do so, you need to ensure a userspace [podman socket](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html) is running.
+  ```bash
+  # Start a rootless podman socket (one-time, won't persist after reboots)
+  $ systemctl --user start podman.socket
+  # Start a rootless podman socket (persistent, will restart after reboots)
+  $ systemctl --user enable --now podman.socket
+  # Get the status of the socket
+  $ systemctl --user status podman.socket
   ```
-  podman run --rm --security-opt label=disable --device /dev/fuse --env-file .env ferrisbot:latest
+
+  Then, to run the locally tagged container with the socket passed to it (the uid being used for the mapping is the user invoking podman, `systemctl --user status podman.socket`):
+  ```bash
+   podman run \
+      --rm \
+      --user ferris \
+      -v /run/user/1000/podman/podman.sock:/run/podman/podman.sock \
+      --security-opt label=disable \
+      --env-file .env \
+      localhost/ferris-bot:latest
   ```
+
+  There are security considerations to actually deploy this: exposing the podman socket is insecure as hypothetically if the ferrisbot container gets taken over, an adversary could spawn arbitrary containers on the host. We partially mitigate major threats by targeting *rootless* Podman, thus (hopefully) preventing privelege escallation as we have seen with exposing a *rootful* podman socket. 
+
+  Therefore, it is recommended that a deployment of this is done on a isolated VM, or at the very least, an isolated account running its own seperate podman socket that is not used by anything else.

--- a/ferris-bot.nomad
+++ b/ferris-bot.nomad
@@ -1,0 +1,45 @@
+# Sample nomad config for ferris-bot
+# Caveats:
+# - Requires podman driver https://github.com/hashicorp/nomad-driver-podman
+#   - Podman driver requires the host has podman, and a running podman socket
+#   - For the podman socket I am testing with a userspace (rootless) socket
+#       systemctl --user enable --now podman.socket
+#       systemctl --user status podman.socket
+#   - Example config for nomad that I'm using with nomad-podman-driver
+#```hcl
+# plugin "nomad-driver-podman" {
+#   config {
+#     socket_path = "unix:///run/user/1000/podman/podman.sock"
+#     volumes {
+#       enabled      = true
+#       selinuxlabel = "z"
+#     }
+#   }
+# }
+#```   
+# 
+
+job "ferris-bot" {
+  datacenters = ["dc1"]
+
+  group "ferris-bot-orchestrator" {
+    task "ferris-bot" {
+      driver = "podman"
+      config {
+        image = "ghcr.io/summer-of-rust/ferris-bot/ferris-bot-rust:latest "
+        # This should be updated depending on nomad deployment
+        volumes = [
+          "/run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock"
+        ]
+      }
+      
+      template {
+        data = <<EOH
+DISCORD_TOKEN="pull_from_key_service_or_something_idk"
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+    }
+  }
+}

--- a/ferris-bot.nomad
+++ b/ferris-bot.nomad
@@ -29,8 +29,9 @@ job "ferris-bot" {
         image = "ghcr.io/summer-of-rust/ferris-bot/ferris-bot-rust:latest "
         # This should be updated depending on nomad deployment
         volumes = [
-          "/run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock"
+          "run/user/1000/podman/podman.sock:/run/podman/podman.sock"
         ]
+        user = "ferris"
       }
       
       template {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -8,15 +8,15 @@ use std::io::ErrorKind;
 fn format_output(response: String, syntax_highlight: Option<&str>) -> String {
     if response.len() < 1000 {
         // Response falls within size constraints
-        return format!("```{}\n{}\n```", syntax_highlight.unwrap_or(""), response);
+        format!("```{}\n{}\n```", syntax_highlight.unwrap_or(""), response)
     } else {
         // For UX, truncate components to 1000 chars... should be long enough
         let short_repsonse = &response[0..1000];
-        return format!(
+        format!(
             "```{}\n{}[TRUNCATED]```",
             syntax_highlight.unwrap_or(""),
             short_repsonse
-        );
+        )
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -18,8 +18,8 @@ pub const CONTAINER_MEMORY: &ConfigurableItem<&str> = &ConfigurableItem {
     default_value: "100m",
 };
 
-// TODO: add settings for CPU scheduler
-// although, i'm unsure if podman supports userspace containers with different schedulers
+// TODO: add settings for CPU scheduler although, i'm unsure if podman supports
+// userspace containers with different schedulers
 
 /// Sets the maximum amount of swap usable to the child container
 pub const CONTAINER_SWAP: &ConfigurableItem<&str> = &ConfigurableItem {
@@ -33,10 +33,15 @@ pub const CONTAINER_MAX_RUNTIME: &ConfigurableItem<u64> = &ConfigurableItem {
     default_value: 5000,
 };
 
-// Tells the bot if it's running in a container
-// this will influence flags it chooses for child containers
-// available values: false,true
+/// Tells the bot if it's running in a container this will influence flags it
+/// chooses for child containers available values: false,true
 pub const IS_RUNNING_IN_CONTAINER: &ConfigurableItem<bool> = &ConfigurableItem {
     environment_variable: "CONTAINER_SWAP",
     default_value: false,
+};
+
+// Specifies whether the container should have networking
+pub const CONTAINER_NETWORK: &ConfigurableItem<&str> = &ConfigurableItem {
+    environment_variable: "CONTAINER_NETWORK",
+    default_value: "none",
 };

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -36,7 +36,7 @@ pub const CONTAINER_MAX_RUNTIME: &ConfigurableItem<u64> = &ConfigurableItem {
 /// Tells the bot if it's running in a container this will influence flags it
 /// chooses for child containers available values: false,true
 pub const IS_RUNNING_IN_CONTAINER: &ConfigurableItem<bool> = &ConfigurableItem {
-    environment_variable: "CONTAINER_SWAP",
+    environment_variable: "IS_RUNNING_IN_CONTAINER",
     default_value: false,
 };
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,5 +1,3 @@
-use base64::Config;
-
 use crate::model::configurable::*;
 
 /// Sets the container image to pull
@@ -51,5 +49,5 @@ pub const CONTAINER_NETWORK: &ConfigurableItem<&str> = &ConfigurableItem {
 // Maximum amount of PIDs available to a container
 pub const CONTAINER_PIDS: &ConfigurableItem<u64> = &ConfigurableItem {
     environment_variable: "MAX_PIDS",
-    default_value: 64
+    default_value: 64,
 };

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,3 +1,5 @@
+use base64::Config;
+
 use crate::model::configurable::*;
 
 /// Sets the container image to pull
@@ -44,4 +46,10 @@ pub const IS_RUNNING_IN_CONTAINER: &ConfigurableItem<bool> = &ConfigurableItem {
 pub const CONTAINER_NETWORK: &ConfigurableItem<&str> = &ConfigurableItem {
     environment_variable: "CONTAINER_NETWORK",
     default_value: "none",
+};
+
+// Maximum amount of PIDs available to a container
+pub const CONTAINER_PIDS: &ConfigurableItem<u64> = &ConfigurableItem {
+    environment_variable: "MAX_PIDS",
+    default_value: 64
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod configuration;
 mod model;
 use crate::commands::{quiz, run};
 use crate::model::container::{get_container_settings, ContainerActions};
+use std::process::exit;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Context<'a> = poise::Context<'a, Data, Error>;
@@ -29,6 +30,9 @@ async fn main() {
     // https://github.com/TheConner/RustBot/pkgs/container/rustbot-runner
     if let Err(e) = get_container_settings().pull_image() {
         println!("Error pulling image: {:?}", e);
+
+        // Fail & bail
+        exit(-1);
     };
 
     println!("Starting up...");

--- a/src/model/container.rs
+++ b/src/model/container.rs
@@ -13,7 +13,7 @@ pub struct ContainerSettings {
     pub image: String,
     pub max_runtime: u64,
     pub network: String,
-    pub pid_limit: u64
+    pub pid_limit: u64,
 }
 
 pub trait ContainerActions {
@@ -74,7 +74,7 @@ impl ContainerActions for ContainerSettings {
             command
         );
 
-         println!("{}", container_command);
+        println!("{}", container_command);
 
         // Because std::command does not give me the ability to override / modify
         // how arguments are escaped I have to do some stupid hack to make this
@@ -110,6 +110,6 @@ pub fn get_container_settings() -> ContainerSettings {
         swap: (*configuration::CONTAINER_SWAP).value(),
         max_runtime: (*configuration::CONTAINER_MAX_RUNTIME).value(),
         network: (*configuration::CONTAINER_NETWORK).value(),
-        pid_limit: (*configuration::CONTAINER_PIDS).value()
+        pid_limit: (*configuration::CONTAINER_PIDS).value(),
     }
 }

--- a/src/model/container.rs
+++ b/src/model/container.rs
@@ -12,6 +12,7 @@ pub struct ContainerSettings {
     pub swap: String,
     pub image: String,
     pub max_runtime: u64,
+    pub network: String,
 }
 
 pub trait ContainerActions {
@@ -31,7 +32,10 @@ impl ContainerActions for ContainerSettings {
         if is_container {
             String::from("")
         } else {
-            format!("--cpus={} --memory={}", self.cpu, self.memory)
+            format!(
+                "--cpus={} --memory={} --network={}",
+                self.cpu, self.memory, self.network
+            )
         }
     }
 
@@ -98,5 +102,6 @@ pub fn get_container_settings() -> ContainerSettings {
         memory: (*configuration::CONTAINER_MEMORY).value(),
         swap: (*configuration::CONTAINER_SWAP).value(),
         max_runtime: (*configuration::CONTAINER_MAX_RUNTIME).value(),
+        network: (*configuration::CONTAINER_NETWORK).value(),
     }
 }

--- a/src/model/container.rs
+++ b/src/model/container.rs
@@ -13,35 +13,41 @@ pub struct ContainerSettings {
     pub image: String,
     pub max_runtime: u64,
     pub network: String,
+    pub pid_limit: u64
 }
 
 pub trait ContainerActions {
-    fn generate_runtime_flags(&self, is_container: bool) -> String;
+    fn container_command(&self) -> String;
+    fn generate_runtime_flags(&self) -> String;
     fn pull_image(&self) -> Result<(), Error>;
     fn invoke_command(&self, command: String) -> io::Result<std::process::Child>;
 }
 
 impl ContainerActions for ContainerSettings {
-    /// Turns a ContainerSettings instance into a string of CLI args for Podman or Docker
-    /// is_container: describes if we are running rustbot in a container
-    fn generate_runtime_flags(&self, is_container: bool) -> String {
-        // BUG: when swap is included, we get a OCI runtime error as memory+swap is greater than configured memory
-        // fix and re-add swap constraint
-        // NOTE: podman-in-podman requires cgroups to set resources, which isn't available within nested containers
-        // so, admins will have to limit the resources on the outer container themselves
-        if is_container {
-            String::from("")
+    /// Gets the container command to use
+    /// Either podman-remote or podman
+    fn container_command(&self) -> String {
+        // Are we running this in a container?
+        if configuration::IS_RUNNING_IN_CONTAINER.value() {
+            // Invoke podman with remote socket that should be passed to the container
+            String::from("podman-remote")
         } else {
-            format!(
-                "--cpus={} --memory={} --network={}",
-                self.cpu, self.memory, self.network
-            )
+            // Invoke podman the default way
+            String::from("podman")
         }
+    }
+
+    /// Turns a ContainerSettings instance into a string of CLI args for Podman or Docker
+    fn generate_runtime_flags(&self) -> String {
+        format!(
+            "--cap-drop=ALL --security-opt=no-new-privileges --cpus={} --memory={} --network={} --pids-limit={}",
+            self.cpu, self.memory, self.network, self.pid_limit
+        )
     }
 
     /// Pulls a container image from a registry
     fn pull_image(&self) -> Result<(), Error> {
-        let output = Command::new("podman")
+        let output = Command::new(self.container_command())
             .arg("pull")
             .arg(&self.image)
             .status()
@@ -61,13 +67,14 @@ impl ContainerActions for ContainerSettings {
 
     fn invoke_command(&self, command: String) -> io::Result<std::process::Child> {
         let container_command = format!(
-            "podman run --rm {} {} {}",
-            self.generate_runtime_flags(configuration::IS_RUNNING_IN_CONTAINER.value()),
+            "{} run --rm {} {} {}",
+            self.container_command(),
+            self.generate_runtime_flags(),
             self.image,
             command
         );
 
-        //println!("{}", container_command);
+         println!("{}", container_command);
 
         // Because std::command does not give me the ability to override / modify
         // how arguments are escaped I have to do some stupid hack to make this
@@ -103,5 +110,6 @@ pub fn get_container_settings() -> ContainerSettings {
         swap: (*configuration::CONTAINER_SWAP).value(),
         max_runtime: (*configuration::CONTAINER_MAX_RUNTIME).value(),
         network: (*configuration::CONTAINER_NETWORK).value(),
+        pid_limit: (*configuration::CONTAINER_PIDS).value()
     }
 }

--- a/src/model/runnable.rs
+++ b/src/model/runnable.rs
@@ -57,13 +57,11 @@ impl Runnable for String {
         // a shell with a payload I deem as safe
         let process = container_settings.invoke_command(container_command);
 
-        let output = process?
+        process?
             .controlled_with_output()
             .time_limit(Duration::from_millis(container_settings.max_runtime))
             .terminate_for_timeout()
             .wait()?
-            .ok_or_else(|| Error::new(io::ErrorKind::TimedOut, "Process timed out"));
-
-        output
+            .ok_or_else(|| Error::new(io::ErrorKind::TimedOut, "Process timed out"))
     }
 }


### PR DESCRIPTION
Requires #7, bundled into this PR

**Changes**

- Adopt a sibling container setup instead of child containers. Too many limitations exist with child containers (cannot limit cpu, memory, etc) which increases the likelihood that child container resource exhaustion can cause the bot executor container to crash
- Add `MAX_PIDS` configuration option to prevent forkbombs from exhausting resources on the host
- Change bot container to use `podman-remote` coupled with a leaked podman socket for managing containers. In the future, making a distributed version of this with better permissions controls (limiting / filtering calls to the Podman socket) will increase scalability and security
- Change container image to not be the bloated podman image, use basic centos stream 9 instead.
- Add basic nomad config, along with instructions to use the nomad-podman plugin to make this all work
- Readme updates