### PR TITLE
Fix build: change ghcr repo to seasons-of-rust

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/summer-of-rust/ferris-bot/ferris-bot-rust:latest
+          tags: ghcr.io/seasons-of-rust/ferris-bot/ferris-bot-rust:latest


### PR DESCRIPTION
Looks like the parent org of this repo is "Seasons-Of-Rust", not "Summer-Of-Rust". 